### PR TITLE
Create github action to update main repository for each push from submodules

### DIFF
--- a/.github/workflow/update_main_repo.yml
+++ b/.github/workflow/update_main_repo.yml
@@ -1,0 +1,19 @@
+name: Notify Main Repo
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  notify-main-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger main repo workflow
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.BOT_PAT }}          # 👈 PAT instead of DISPATCH_TOKEN
+          repository: elytra-tqs/elytra
+          event-type: submodule-updated
+          client-payload: >
+            {"submodule_name":"${{ github.repository }}",
+             "commit_sha":"${{ github.sha }}"}
+

--- a/.github/workflow/update_main_repo.yml
+++ b/.github/workflow/update_main_repo.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Trigger main repo workflow
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.BOT_PAT }}          # 👈 PAT instead of DISPATCH_TOKEN
+          token: ${{ secrets.BOT_PAT }}
           repository: elytra-tqs/elytra
           event-type: submodule-updated
           client-payload: >


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to notify the main repository when updates are pushed to the `dev` branch. The workflow uses the `repository-dispatch` action to trigger an event in the main repository.

### New GitHub Actions Workflow:

* [`.github/workflow/update_main_repo.yml`](diffhunk://#diff-261d0be952aad24e426ef33f8207dd8479d7f21b5a52d674a42458280b445623R1-R19): Added a new workflow named "Notify Main Repo" that triggers on pushes to the `dev` branch. It uses the `peter-evans/repository-dispatch` action to send a `submodule-updated` event to the main repository (`elytra-tqs/elytra`) with relevant payload information, including the submodule name and commit SHA.