### PR TITLE
El 46 add sonarcloud to all repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu' # Alternative distribution options are available.
       - name: Cache SonarQube packages
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,8 @@ jobs:
             -Dsonar.tests=src/test/java
             -Dsonar.java.binaries=target/classes
             -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
-            -Dsonar.branch.name=main
+            -Dsonar.verbose=true
+
 
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,62 +1,38 @@
-name: SonarQube Analysis with Quality Gate
+name: SonarQube
 on:
   push:
     branches:
+      - main
+      - dev
       - EL-46-Add-sonarcloud-to-all-repositories
   pull_request:
     types: [opened, synchronize, reopened]
-  workflow_dispatch:
 jobs:
-  build-and-analyze:
-    name: Build, Analyze, and Check Quality Gate
+  build:
+    name: Build and analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-      
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 21
-          distribution: 'temurin'
-          cache: maven
-      
+          java-version: 17
+          distribution: 'zulu' # Alternative distribution options are available.
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      
-      - name: Build and run tests
-        run: mvn -B clean verify
-      
-      - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@master
+      - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        with:
-          args: >
-            -Dsonar.projectKey=elytra-tqs_stations-management
-            -Dsonar.organization=elytra-tqs
-            -Dsonar.sources=src/main/java
-            -Dsonar.tests=src/test/java
-            -Dsonar.java.binaries=target/classes
-            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
-      
-      - name: SonarQube Quality Gate check
-        id: sonarqube-quality-gate-check
-        uses: sonarsource/sonarqube-quality-gate-action@master
-        timeout-minutes: 5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      
-      - name: "SonarQube Quality Gate Status"
-        run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
-      
-      - name: "Fail if Quality Gate fails"
-        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'FAILED'
-        run: exit 1
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=elytra-tqs_stations-management -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: SonarQube Analysis with Quality Gate
 on:
   push:
     branches:
-      - main
+      - EL-46-Add-sonarcloud-to-all-repositories
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: SonarQube Analysis with Quality Gate
+
+on:
+  push:
+    branches:
+      - EL-46-Add-sonarcloud-to-all-repositories
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  build-and-analyze:
+    name: Build, Analyze, and Check Quality Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build and run tests
+        run: mvn -B clean verify
+
+      - name: SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+        with:
+          args: >
+            -Dsonar.projectKey=elytra-tqs_stations-management
+            -Dsonar.organization=elytra-tqs
+            -Dsonar.sources=src/main/java
+            -Dsonar.tests=src/test/java
+            -Dsonar.java.binaries=target/classes
+            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+            -Dsonar.branch.name=main
+
+      - name: SonarQube Quality Gate check
+        id: sonarqube-quality-gate-check
+        uses: sonarsource/sonarqube-quality-gate-action@master
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+
+      - name: "SonarQube Quality Gate Status"
+        run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
+
+      - name: "Fail if Quality Gate fails"
+        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'FAILED'
+        run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: SonarQube Analysis with Quality Gate
 on:
   push:
     branches:
-      - EL-46-Add-sonarcloud-to-all-repositories
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,23 @@ jobs:
         id: sonarqube-quality-gate-check
         uses: sonarsource/sonarqube-quality-gate-action@master
         timeout-minutes: 5
+        with:
+          scanMetadataReportFile: .scannerwork/report-task.txt
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
+      
+      - name: Check SonarQube report file
+        run: |
+          echo "Checking for report file..."
+          if [ -f .scannerwork/report-task.txt ]; then
+            echo "Report file found. Contents:"
+            cat .scannerwork/report-task.txt
+          else
+            echo "Report file not found. Contents of .scannerwork directory:"
+            ls -la .scannerwork/ || echo ".scannerwork directory not found"
+          fi
+        continue-on-error: true
 
       - name: "SonarQube Quality Gate Status"
         run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,45 +1,42 @@
 name: SonarQube Analysis with Quality Gate
-
 on:
   push:
     branches:
-      - EL-46-Add-sonarcloud-to-all-repositories
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
-
 jobs:
   build-and-analyze:
     name: Build, Analyze, and Check Quality Gate
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
+      
       - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: 21
           distribution: 'temurin'
           cache: maven
-
+      
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-
+      
       - name: Build and run tests
         run: mvn -B clean verify
-
+      
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         with:
           args: >
             -Dsonar.projectKey=elytra-tqs_stations-management
@@ -48,34 +45,18 @@ jobs:
             -Dsonar.tests=src/test/java
             -Dsonar.java.binaries=target/classes
             -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
-            -Dsonar.verbose=true
-
-
-      # - name: SonarQube Quality Gate check
-      #   id: sonarqube-quality-gate-check
-      #   uses: sonarsource/sonarqube-quality-gate-action@master
-      #   timeout-minutes: 5
-      #   with:
-      #     scanMetadataReportFile: .scannerwork/report-task.txt
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #     SONAR_HOST_URL: https://sonarcloud.io
       
-      # - name: Check SonarQube report file
-      #   run: |
-      #     echo "Checking for report file..."
-      #     if [ -f .scannerwork/report-task.txt ]; then
-      #       echo "Report file found. Contents:"
-      #       cat .scannerwork/report-task.txt
-      #     else
-      #       echo "Report file not found. Contents of .scannerwork directory:"
-      #       ls -la .scannerwork/ || echo ".scannerwork directory not found"
-      #     fi
-      #   continue-on-error: true
-
-      # - name: "SonarQube Quality Gate Status"
-      #   run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
-
-      # - name: "Fail if Quality Gate fails"
-      #   if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'FAILED'
-      #   run: exit 1
+      - name: SonarQube Quality Gate check
+        id: sonarqube-quality-gate-check
+        uses: sonarsource/sonarqube-quality-gate-action@master
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      
+      - name: "SonarQube Quality Gate Status"
+        run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
+      
+      - name: "Fail if Quality Gate fails"
+        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'FAILED'
+        run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: SonarQube Analysis with Quality Gate
 on:
   push:
     branches:
-      - main
+      - EL-46-Add-sonarcloud-to-all-repositories
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,31 +51,31 @@ jobs:
             -Dsonar.verbose=true
 
 
-      - name: SonarQube Quality Gate check
-        id: sonarqube-quality-gate-check
-        uses: sonarsource/sonarqube-quality-gate-action@master
-        timeout-minutes: 5
-        with:
-          scanMetadataReportFile: .scannerwork/report-task.txt
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
+      # - name: SonarQube Quality Gate check
+      #   id: sonarqube-quality-gate-check
+      #   uses: sonarsource/sonarqube-quality-gate-action@master
+      #   timeout-minutes: 5
+      #   with:
+      #     scanMetadataReportFile: .scannerwork/report-task.txt
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #     SONAR_HOST_URL: https://sonarcloud.io
       
-      - name: Check SonarQube report file
-        run: |
-          echo "Checking for report file..."
-          if [ -f .scannerwork/report-task.txt ]; then
-            echo "Report file found. Contents:"
-            cat .scannerwork/report-task.txt
-          else
-            echo "Report file not found. Contents of .scannerwork directory:"
-            ls -la .scannerwork/ || echo ".scannerwork directory not found"
-          fi
-        continue-on-error: true
+      # - name: Check SonarQube report file
+      #   run: |
+      #     echo "Checking for report file..."
+      #     if [ -f .scannerwork/report-task.txt ]; then
+      #       echo "Report file found. Contents:"
+      #       cat .scannerwork/report-task.txt
+      #     else
+      #       echo "Report file not found. Contents of .scannerwork directory:"
+      #       ls -la .scannerwork/ || echo ".scannerwork directory not found"
+      #     fi
+      #   continue-on-error: true
 
-      - name: "SonarQube Quality Gate Status"
-        run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
+      # - name: "SonarQube Quality Gate Status"
+      #   run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"
 
-      - name: "Fail if Quality Gate fails"
-        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'FAILED'
-        run: exit 1
+      # - name: "Fail if Quality Gate fails"
+      #   if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'FAILED'
+      #   run: exit 1

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<sonar.organization>elytra-tqs</sonar.organization>
+    	<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -63,6 +65,25 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.10</version>
+				<executions>
+					<execution>
+					<goals>
+						<goal>prepare-agent</goal>
+					</goals>
+					</execution>
+					<execution>
+					<id>report</id>
+					<phase>verify</phase>
+					<goals>
+						<goal>report</goal>
+					</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## Description

This pull request introduces SonarQube integration into the project for code quality analysis and test coverage reporting. The changes include adding a GitHub Actions workflow for SonarQube, updating the Maven `pom.xml` file to configure SonarCloud, and adding the JaCoCo Maven plugin for test coverage reporting.

### SonarQube Integration:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R38): Added a new GitHub Actions workflow named "SonarQube" to run on pushes to specific branches and pull requests. It sets up JDK 21, caches dependencies, and performs a build and SonarQube analysis using the Sonar Maven plugin.

### Maven Configuration Updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R32-R33): Added SonarCloud configuration properties (`sonar.organization` and `sonar.host.url`) to enable integration with SonarCloud.

### Test Coverage Reporting:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R69-R87): Added the JaCoCo Maven plugin to generate test coverage reports, including configurations for `prepare-agent` and `report` executions during the `verify` phase.