### PR TITLE
Changing status field to charger

### DIFF
--- a/src/main/java/elytra/stations_management/models/Charger.java
+++ b/src/main/java/elytra/stations_management/models/Charger.java
@@ -2,14 +2,7 @@ package elytra.stations_management.models;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -37,4 +30,15 @@ public class Charger {
     @ManyToOne
     @JoinColumn(name = "station_id", nullable = false)
     private Station station;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status = Status.AVAILABLE;
+
+    public enum Status {
+        AVAILABLE,
+        BEING_USED,
+        UNDER_MAINTENANCE,
+        OUT_OF_SERVICE
+    }
 }

--- a/src/main/java/elytra/stations_management/models/Station.java
+++ b/src/main/java/elytra/stations_management/models/Station.java
@@ -32,17 +32,11 @@ public class Station {
     private Double latitude;
     private Double longitude;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private MaintenanceStatus maintenanceStatus = MaintenanceStatus.OPERATIONAL;
+
 
     @JsonManagedReference
     @OneToMany(mappedBy = "station", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Charger> chargers = new ArrayList<>();
 
-    public enum MaintenanceStatus {
-        OPERATIONAL,
-        UNDER_MAINTENANCE,
-        OUT_OF_SERVICE
-    }
+
 }

--- a/src/test/java/elytra/stations_management/StationRepositoryTest.java
+++ b/src/test/java/elytra/stations_management/StationRepositoryTest.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import elytra.stations_management.models.Station;
-import elytra.stations_management.models.Station.MaintenanceStatus;
 
 @DataJpaTest
 class StationRepositoryTest {
@@ -23,7 +22,6 @@ class StationRepositoryTest {
                 .address("123 Main St")
                 .latitude(40.12345)
                 .longitude(-8.54321)
-                .maintenanceStatus(MaintenanceStatus.OPERATIONAL)
                 .build();
         Station saved = stationRepository.save(station);
         Optional<Station> found = stationRepository.findById(saved.getId());


### PR DESCRIPTION
This pull request introduces changes to the `Charger` and `Station` models to enhance the management of charger statuses and simplify the `Station` entity. It adds a new `Status` enum to the `Charger` model while removing the `MaintenanceStatus` enum from the `Station` model. Corresponding updates are made to the test files to reflect these changes.

### Model Updates:

* [`Charger.java`](diffhunk://#diff-dbdb901a334bc53c68835f955962dd7fdb7f419840a685306dff64d077164e3dR33-R43): Introduced a `Status` enum to represent the state of a charger (`AVAILABLE`, `BEING_USED`, `UNDER_MAINTENANCE`, `OUT_OF_SERVICE`). Added a `status` field to the `Charger` class, defaulting to `Status.AVAILABLE`.
* [`Station.java`](diffhunk://#diff-5d8268bd78c6635f773429e98efdcf26e3292cc8ddbf8fbc623d25f3e1d8af35L35-R41): Removed the `MaintenanceStatus` enum and its associated `maintenanceStatus` field to simplify the `Station` model.

### Test Updates:

* [`StationRepositoryTest.java`](diffhunk://#diff-eef0c3311ed706b5b3479fcbe3cde05eb6dfe397526de4508929866d43375942L12): Removed references to the `MaintenanceStatus` enum and its usage in the `saveAndRetrieveStation` test method to align with the updated `Station` model. [[1]](diffhunk://#diff-eef0c3311ed706b5b3479fcbe3cde05eb6dfe397526de4508929866d43375942L12) [[2]](diffhunk://#diff-eef0c3311ed706b5b3479fcbe3cde05eb6dfe397526de4508929866d43375942L26)