### PR TITLE
bugfix: cors mappings

### DIFF
--- a/src/main/java/elytra/stations_management/config/WebConfig.java
+++ b/src/main/java/elytra/stations_management/config/WebConfig.java
@@ -3,6 +3,7 @@ package elytra.stations_management.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,5 +17,15 @@ public class WebConfig implements WebMvcConfigurer {
                 .defaultContentType(MediaType.APPLICATION_JSON)
                 .ignoreAcceptHeader(true)
                 .useRegisteredExtensionsOnly(true);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("*") 
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(false) 
+            .maxAge(3600); 
     }
 }

--- a/src/main/java/elytra/stations_management/config/WebConfig.java
+++ b/src/main/java/elytra/stations_management/config/WebConfig.java
@@ -22,7 +22,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins("*") 
+            .allowedOrigins(
+                "http://localhost:5173", 
+                "http://frontend:5173",
+                "http://127.0.0.1:5173"
+            ) 
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(false) 


### PR DESCRIPTION
## Description
This pull request introduces a new method to configure Cross-Origin Resource Sharing (CORS) in the `WebConfig` class. The most notable change is the addition of the `addCorsMappings` method to allow flexible CORS settings for the application.

### CORS Configuration:

* [`src/main/java/elytra/stations_management/config/WebConfig.java`](diffhunk://#diff-bb16f7df04c41b36af543c2ac8261244a08ac72d18e60649318e147109b582d2R21-R30): Added the `addCorsMappings` method to define CORS settings, allowing all origins, methods (`GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`), and headers, with credentials disabled and a max age of 3600 seconds. This ensures the application can handle cross-origin requests flexibly.