### PR TITLE
Put and Delete methods in Stations API

### DIFF
--- a/src/main/java/elytra/stations_management/controller/StationController.java
+++ b/src/main/java/elytra/stations_management/controller/StationController.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,6 +42,16 @@ public class StationController {
         return stationService.getAllStations();
     }
 
+    @GetMapping(value = "/{stationId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Station> getStationById(@PathVariable Long stationId) {
+        try {
+            Station station = stationService.getStationById(stationId);
+            return ResponseEntity.ok(station);
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     @GetMapping(value = "/{stationId}/chargers", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<Charger>> getChargersByStation(@PathVariable Long stationId) {
         try {
@@ -55,6 +67,26 @@ public class StationController {
         try {
             Charger createdCharger = stationService.addChargerToStation(stationId, charger);
             return ResponseEntity.status(HttpStatus.CREATED).body(createdCharger);
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PutMapping(value = "/{stationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Station> updateStation(@PathVariable Long stationId, @RequestBody Station station) {
+        try {
+            Station updatedStation = stationService.updateStation(stationId, station);
+            return ResponseEntity.ok(updatedStation);
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping(value = "/{stationId}")
+    public ResponseEntity<Void> deleteStation(@PathVariable Long stationId) {
+        try {
+            stationService.deleteStation(stationId);
+            return ResponseEntity.noContent().build();
         } catch (RuntimeException e) {
             return ResponseEntity.notFound().build();
         }

--- a/src/main/java/elytra/stations_management/services/StationService.java
+++ b/src/main/java/elytra/stations_management/services/StationService.java
@@ -43,4 +43,32 @@ public class StationService {
         stationRepository.save(station);
         return charger;
     }
+
+    @Transactional
+    public Station updateStation(Long stationId, Station station) {
+        Station existingStation = getStationById(stationId);
+        existingStation.setName(station.getName());
+        existingStation.setAddress(station.getAddress());
+        existingStation.setLatitude(station.getLatitude());
+        existingStation.setLongitude(station.getLongitude());
+
+
+        existingStation.getChargers().clear();
+        if (station.getChargers() != null) {
+            for (Charger charger : station.getChargers()) {
+                charger.setStation(existingStation);
+                existingStation.getChargers().add(charger);
+            }
+        }
+        stationRepository.save(existingStation);
+
+        return existingStation;
+    }
+
+    @Transactional
+    public void deleteStation(Long stationId) {
+        Station station = stationRepository.findById(stationId)
+                .orElseThrow(() -> new RuntimeException("Station not found"));
+        stationRepository.delete(station);
+    }
 }


### PR DESCRIPTION
This pull request introduces new functionality to manage stations in the `stations_management` module, including retrieving, updating, and deleting stations. It also adds corresponding service methods and unit tests to ensure the correctness of these operations. The changes primarily focus on enhancing the `StationController`, `StationService`, and their respective test classes.

### Controller Enhancements:
* **New HTTP Methods**: Added `@PutMapping` and `@DeleteMapping` annotations to support updating and deleting stations. (`StationController.java`)
* **Retrieve Station by ID**: Implemented a new endpoint to fetch station details by ID, returning a `404 Not Found` response if the station does not exist. (`StationController.java`)
* **Update and Delete Endpoints**: Added endpoints for updating station details and deleting a station. Both endpoints handle runtime exceptions gracefully by returning appropriate HTTP status codes. (`StationController.java`)

### Service Layer Updates:
* **Update Station Logic**: Created a transactional method to update station details, including replacing chargers and setting their references to the updated station. (`StationService.java`)
* **Delete Station Logic**: Added a transactional method to delete a station, throwing an exception if the station is not found. (`StationService.java`)

### Testing Enhancements:
* **Controller Tests**: Extended `StationControllerTest` to include tests for retrieving, updating, and deleting stations, including scenarios for invalid IDs. (`StationControllerTest.java`) [[1]](diffhunk://#diff-08c8ed012bbb9b1a2b4279cd59bc1e66f5ad441eecb482762366b9e8ae1dc459L125-R140) [[2]](diffhunk://#diff-08c8ed012bbb9b1a2b4279cd59bc1e66f5ad441eecb482762366b9e8ae1dc459R227-R300)
* **Service Tests**: Added unit tests in `StationServiceTest` to validate the update and delete logic, including handling chargers and verifying repository interactions. (`StationServiceTest.java`)