### PR TITLE
El 114 create button to delete and edit stations and chargers

### DIFF
--- a/src/main/java/elytra/stations_management/controller/ChargerController.java
+++ b/src/main/java/elytra/stations_management/controller/ChargerController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,5 +40,26 @@ public class ChargerController {
     @GetMapping("/availability/{status}")
     public ResponseEntity<List<Charger>> getChargersByAvailability(@PathVariable Charger.Status status) {
         return ResponseEntity.ok(chargerService.getChargersByAvailability(status));
+    }
+
+    @PutMapping("/{chargerId}")
+    public ResponseEntity<Charger> updateCharger(
+            @PathVariable Long chargerId,
+            @RequestBody Charger charger) {
+        try {
+            return ResponseEntity.ok(chargerService.updateCharger(chargerId, charger));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @DeleteMapping("/{chargerId}")
+    public ResponseEntity<Void> deleteCharger(@PathVariable Long chargerId) {
+        try {
+            chargerService.deleteCharger(chargerId);
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
     }
 }

--- a/src/main/java/elytra/stations_management/services/ChargerService.java
+++ b/src/main/java/elytra/stations_management/services/ChargerService.java
@@ -40,6 +40,28 @@ public class ChargerService {
         return chargerRepository.findByStatus(status);
     }
 
+    @Transactional
+    public Charger updateCharger(Long chargerId, Charger updatedCharger) {
+        Charger existingCharger = chargerRepository.findById(chargerId)
+                .orElseThrow(() -> new RuntimeException("Charger not found"));
+
+        existingCharger.setType(updatedCharger.getType());
+        existingCharger.setPower(updatedCharger.getPower());
+        
+        if (updatedCharger.getStatus() != null) {
+            validateStatusTransition(existingCharger.getStatus(), updatedCharger.getStatus());
+            existingCharger.setStatus(updatedCharger.getStatus());
+        }
+
+        return chargerRepository.save(existingCharger);
+    }
+
+    @Transactional
+    public void deleteCharger(Long chargerId) {
+        Charger charger = chargerRepository.findById(chargerId)
+                .orElseThrow(() -> new RuntimeException("Charger not found"));
+        chargerRepository.delete(charger);
+    }
 
     private void validateStatusTransition(Charger.Status currentStatus,
             Charger.Status newStatus) {


### PR DESCRIPTION
## Description
This pull request adds new functionality to manage chargers, including the ability to update and delete chargers, along with corresponding service methods and tests. It also fixes a minor typo in an existing test route. Below are the key changes grouped by theme:

### Controller Enhancements:
* Added `@PutMapping` and `@DeleteMapping` endpoints in `ChargerController` to allow updating and deleting chargers. These endpoints handle exceptions to return appropriate HTTP status codes.

### Service Layer Updates:
* Introduced `updateCharger` and `deleteCharger` methods in `ChargerService` to handle charger updates and deletions. The `updateCharger` method includes logic for validating status transitions, while `deleteCharger` ensures the charger exists before deletion. Both methods throw exceptions when the charger is not found.

### Test Coverage:
* Added unit tests in `ChargerControllerTest` to validate the behavior of the new endpoints, including successful operations and error scenarios (e.g., invalid status transitions or non-existent chargers).
* Added unit tests in `ChargerServiceTest` to verify the correctness of the new service methods, including exception handling and status validation logic.

### Minor Fixes:
* Corrected a typo in the `getChargersByAvailability` test route in `ChargerControllerTest` (removed an extra `/` in the URL).