### PR TITLE
add auto update action

### DIFF
--- a/.github/workflows/notify-main.yml
+++ b/.github/workflows/notify-main.yml
@@ -1,0 +1,23 @@
+name: Notify Main Repository
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  notify-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger main repository update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          repository: elytra-tqs/elytra
+          event-type: submodule-updated
+          client-payload: |
+            {
+              "submodule_name": "stations-management",
+              "commit_sha": "${{ github.sha }}",
+              "branch": "dev"
+            }


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to notify the main repository when changes are pushed to the `dev` branch of the current repository.

### New GitHub Actions Workflow:

* [`.github/workflows/notify-main.yml`](diffhunk://#diff-5b4f61144f03536a814b3cb719999dfe8c42ee230f8c0b7d32a73abc645d91e0R1-R23): Added a workflow named "Notify Main Repository" that triggers on pushes to the `dev` branch. It uses the `peter-evans/repository-dispatch` action to send a repository dispatch event to the main repository (`elytra-tqs/elytra`) with details about the updated submodule, including its name, commit SHA, and branch.