### PR TITLE
admin is created when the app is initialized and the station operator…

### DIFF
--- a/app.log
+++ b/app.log
@@ -1,0 +1,77 @@
+[INFO] Scanning for projects...
+[INFO] 
+[INFO] -----------< elytra.stations-management:stations-management >-----------
+[INFO] Building stations-management 0.0.1-SNAPSHOT
+[INFO]   from pom.xml
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] >>> spring-boot:3.2.3:run (default-cli) > test-compile @ stations-management >>>
+[INFO] 
+[INFO] --- jacoco:0.8.11:prepare-agent (prepare-agent) @ stations-management ---
+[INFO] argLine set to -javaagent:/Users/martimsantos/.m2/repository/org/jacoco/org.jacoco.agent/0.8.11/org.jacoco.agent-0.8.11-runtime.jar=destfile=/Users/martimsantos/Desktop/Universidade/elytra/stations-management/target/jacoco.exec,excludes=**/StationsManagementApplication.class
+[INFO] 
+[INFO] --- resources:3.3.1:resources (default-resources) @ stations-management ---
+[INFO] Copying 2 resources from src/main/resources to target/classes
+[INFO] Copying 0 resource from src/main/resources to target/classes
+[INFO] 
+[INFO] --- compiler:3.11.0:compile (default-compile) @ stations-management ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO] 
+[INFO] --- resources:3.3.1:testResources (default-testResources) @ stations-management ---
+[INFO] Copying 2 resources from src/test/resources to target/test-classes
+[INFO] 
+[INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ stations-management ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO] 
+[INFO] <<< spring-boot:3.2.3:run (default-cli) < test-compile @ stations-management <<<
+[INFO] 
+[INFO] 
+[INFO] --- spring-boot:3.2.3:run (default-cli) @ stations-management ---
+[INFO] Attaching agents: []
+
+  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  '  |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/
+ :: Spring Boot ::                (v3.2.3)
+
+2025-06-05T04:42:40.853+01:00  INFO 52896 --- [stations-management] [  restartedMain] e.s.StationsManagementApplication        : Starting StationsManagementApplication using Java 21.0.3 with PID 52896 (/Users/martimsantos/Desktop/Universidade/elytra/stations-management/target/classes started by martimsantos in /Users/martimsantos/Desktop/Universidade/elytra/stations-management)
+2025-06-05T04:42:40.854+01:00  INFO 52896 --- [stations-management] [  restartedMain] e.s.StationsManagementApplication        : No active profile set, falling back to 1 default profile: "default"
+2025-06-05T04:42:40.870+01:00  INFO 52896 --- [stations-management] [  restartedMain] .e.DevToolsPropertyDefaultsPostProcessor : Devtools property defaults active! Set 'spring.devtools.add-properties' to 'false' to disable
+2025-06-05T04:42:40.870+01:00  INFO 52896 --- [stations-management] [  restartedMain] .e.DevToolsPropertyDefaultsPostProcessor : For additional web related logging consider setting the 'logging.level.web' property to 'DEBUG'
+2025-06-05T04:42:41.534+01:00  INFO 52896 --- [stations-management] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2025-06-05T04:42:41.573+01:00  INFO 52896 --- [stations-management] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 33 ms. Found 8 JPA repository interfaces.
+2025-06-05T04:42:41.930+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
+2025-06-05T04:42:41.935+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
+2025-06-05T04:42:41.935+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.19]
+2025-06-05T04:42:41.952+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
+2025-06-05T04:42:41.953+01:00  INFO 52896 --- [stations-management] [  restartedMain] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 1083 ms
+2025-06-05T04:42:42.009+01:00  INFO 52896 --- [stations-management] [  restartedMain] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
+2025-06-05T04:42:42.071+01:00  INFO 52896 --- [stations-management] [  restartedMain] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection conn0: url=jdbc:h2:mem:testdb user=SA
+2025-06-05T04:42:42.071+01:00  INFO 52896 --- [stations-management] [  restartedMain] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
+2025-06-05T04:42:42.074+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.s.b.a.h2.H2ConsoleAutoConfiguration    : H2 console available at '/h2-console'. Database available at 'jdbc:h2:mem:testdb'
+2025-06-05T04:42:42.142+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.hibernate.jpa.internal.util.LogHelper  : HHH000204: Processing PersistenceUnitInfo [name: default]
+2025-06-05T04:42:42.161+01:00  INFO 52896 --- [stations-management] [  restartedMain] org.hibernate.Version                    : HHH000412: Hibernate ORM core version 6.4.4.Final
+2025-06-05T04:42:42.171+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.h.c.internal.RegionFactoryInitiator    : HHH000026: Second-level cache disabled
+2025-06-05T04:42:42.242+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.s.o.j.p.SpringPersistenceUnitInfo      : No LoadTimeWeaver setup: ignoring JPA class transformer
+2025-06-05T04:42:42.256+01:00  WARN 52896 --- [stations-management] [  restartedMain] org.hibernate.orm.deprecation            : HHH90000025: H2Dialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2025-06-05T04:42:42.578+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.h.e.t.j.p.i.JtaPlatformInitiator       : HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2025-06-05T04:42:42.600+01:00  INFO 52896 --- [stations-management] [  restartedMain] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
+2025-06-05T04:42:42.860+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.s.d.j.r.query.QueryEnhancerFactory     : Hibernate is in classpath; If applicable, HQL parser will be used.
+2025-06-05T04:42:43.164+01:00  WARN 52896 --- [stations-management] [  restartedMain] JpaBaseConfiguration$JpaWebConfiguration : spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2025-06-05T04:42:43.308+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 4 endpoint(s) beneath base path '/actuator'
+2025-06-05T04:42:43.348+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.s.s.web.DefaultSecurityFilterChain     : Will secure any request with [org.springframework.security.web.session.DisableEncodeUrlFilter@5198af9b, org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter@1dea051e, org.springframework.security.web.context.SecurityContextHolderFilter@595ea342, org.springframework.security.web.header.HeaderWriterFilter@f66be34, org.springframework.web.filter.CorsFilter@7eb0a38, org.springframework.security.web.authentication.logout.LogoutFilter@22f8aa84, elytra.stations_management.filter.JwtAuthFilter@47464874, org.springframework.security.web.savedrequest.RequestCacheAwareFilter@37f1900c, org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter@16ce2a69, org.springframework.security.web.authentication.AnonymousAuthenticationFilter@2bbc8c5b, org.springframework.security.web.session.SessionManagementFilter@67acb226, org.springframework.security.web.access.ExceptionTranslationFilter@487666a6, org.springframework.security.web.access.intercept.AuthorizationFilter@2da46bb0]
+2025-06-05T04:42:43.605+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.s.b.d.a.OptionalLiveReloadServer       : LiveReload server is running on port 35729
+2025-06-05T04:42:43.630+01:00  INFO 52896 --- [stations-management] [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path ''
+2025-06-05T04:42:43.636+01:00  INFO 52896 --- [stations-management] [  restartedMain] e.s.StationsManagementApplication        : Started StationsManagementApplication in 2.926 seconds (process running for 3.104)
+2025-06-05T04:42:43.702+01:00  INFO 52896 --- [stations-management] [  restartedMain] e.s.config.DataInitializer               : Creating initial admin user...
+2025-06-05T04:42:43.786+01:00  INFO 52896 --- [stations-management] [  restartedMain] e.s.config.DataInitializer               : Initial admin user created successfully with username: admin
+2025-06-05T04:43:03.059+01:00  INFO 52896 --- [stations-management] [nio-8080-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
+2025-06-05T04:43:03.060+01:00  INFO 52896 --- [stations-management] [nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
+2025-06-05T04:43:03.061+01:00  INFO 52896 --- [stations-management] [nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 1 ms
+2025-06-05T04:44:02.792+01:00  INFO 52896 --- [stations-management] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
+2025-06-05T04:44:02.798+01:00  WARN 52896 --- [stations-management] [ionShutdownHook] o.s.b.f.support.DisposableBeanAdapter    : Invocation of destroy method failed on bean with name 'inMemoryDatabaseShutdownExecutor': org.h2.jdbc.JdbcSQLNonTransientConnectionException: Database is already closed (to disable automatic closing at VM shutdown, add ";DB_CLOSE_ON_EXIT=FALSE" to the db URL) [90121-224]
+2025-06-05T04:44:02.798+01:00  INFO 52896 --- [stations-management] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
+2025-06-05T04:44:02.799+01:00  INFO 52896 --- [stations-management] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.

--- a/src/main/java/elytra/stations_management/config/DataInitializer.java
+++ b/src/main/java/elytra/stations_management/config/DataInitializer.java
@@ -1,0 +1,70 @@
+package elytra.stations_management.config;
+
+import elytra.stations_management.models.Admin;
+import elytra.stations_management.models.User;
+import elytra.stations_management.repositories.UserRepository;
+import elytra.stations_management.services.AdminService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+@Profile("!test")  // Don't run in test profile
+public class DataInitializer {
+
+    private final UserRepository userRepository;
+    private final AdminService adminService;
+
+    @Value("${app.admin.username:admin}")
+    private String adminUsername;
+
+    @Value("${app.admin.password:admin123}")
+    private String adminPassword;
+
+    @Value("${app.admin.email:admin@elytra.com}")
+    private String adminEmail;
+
+    @Value("${app.admin.firstName:System}")
+    private String adminFirstName;
+
+    @Value("${app.admin.lastName:Administrator}")
+    private String adminLastName;
+
+    @Bean
+    public CommandLineRunner initDatabase() {
+        return args -> {
+            try {
+                // Check if admin already exists
+                if (!userRepository.existsByUsername(adminUsername)) {
+                    log.info("Creating initial admin user...");
+                    
+                    // Create admin user
+                    User adminUser = User.builder()
+                            .username(adminUsername)
+                            .password(adminPassword) // Will be encoded in the service
+                            .email(adminEmail)
+                            .firstName(adminFirstName)
+                            .lastName(adminLastName)
+                            .userType(User.UserType.ADMIN)
+                            .build();
+
+                    Admin admin = Admin.builder().build();
+                    
+                    adminService.registerAdmin(admin, adminUser);
+                    
+                    log.info("Initial admin user created successfully with username: {}", adminUsername);
+                } else {
+                    log.info("Admin user already exists, skipping initialization");
+                }
+            } catch (Exception e) {
+                log.error("Failed to create initial admin user: {}", e.getMessage());
+            }
+        };
+    }
+}

--- a/src/main/java/elytra/stations_management/config/SecurityConfig.java
+++ b/src/main/java/elytra/stations_management/config/SecurityConfig.java
@@ -35,8 +35,8 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/register/driver", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/h2-console/**").permitAll()
-                        .requestMatchers("/api/v1/auth/register/operator", "/api/v1/auth/register/admin").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/register/driver", "/api/v1/auth/register/operator", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/h2-console/**").permitAll()
+                        .requestMatchers("/api/v1/auth/register/admin").hasRole("ADMIN")
                         .requestMatchers("/api/v1/auth/me").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/elytra/stations_management/controller/AuthController.java
+++ b/src/main/java/elytra/stations_management/controller/AuthController.java
@@ -132,16 +132,23 @@ public class AuthController {
     }
 
     @PostMapping("/register/operator")
-    @Operation(summary = "Register a new station operator (Admin only)")
+    @Operation(summary = "Register a new station operator (Public)")
     public ResponseEntity<Map<String, Object>> registerOperator(@RequestBody OperatorRegistrationRequest request) {
         try {
+            // Set user type
+            request.getUser().setUserType(User.UserType.STATION_OPERATOR);
+            
             StationOperator operator = stationOperatorService.registerStationOperator(
                     request.getOperator(),
                     request.getUser(),
                     request.getStationId()
             );
 
+            // Generate token for auto-login
+            String token = jwtService.generateToken(request.getUser().getUsername());
+
             Map<String, Object> response = new HashMap<>();
+            response.put("token", token);
             response.put("message", "Station operator registered successfully");
             response.put(USERNAME, operator.getUser().getUsername());
             response.put(USER_TYPE, User.UserType.STATION_OPERATOR);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,3 +26,10 @@ management.health.db.enabled=true
 
 # JWT Configuration
 jwt.secret=${JWT_SECRET}
+
+# Initial Admin Configuration
+app.admin.username=${ADMIN_USERNAME:admin}
+app.admin.password=${ADMIN_PASSWORD:admin123}
+app.admin.email=${ADMIN_EMAIL:admin@elytra.com}
+app.admin.firstName=${ADMIN_FIRST_NAME:System}
+app.admin.lastName=${ADMIN_LAST_NAME:Administrator}


### PR DESCRIPTION
This pull request introduces several significant changes, including the addition of an initial admin user configuration, updates to security rules, and modifications to the registration process for station operators. It also includes corresponding updates to tests and configuration files to support these changes.

### Initial Admin User Setup:
* Added a new `DataInitializer` class to create an initial admin user during application startup if one does not already exist. The admin's credentials and details are configurable via environment variables or default values. (`src/main/java/elytra/stations_management/config/DataInitializer.java`)
* Added properties for admin configuration in `application.properties`, allowing customization of the initial admin user's username, password, email, and name. (`src/main/resources/application.properties`)

### Security Configuration Updates:
* Modified the security filter chain to allow public access to the station operator registration endpoint (`/api/v1/auth/register/operator`). Previously, this endpoint was restricted to admin users. (`src/main/java/elytra/stations_management/config/SecurityConfig.java`)

### Registration Process Changes:
* Updated the `registerOperator` endpoint to make it publicly accessible and automatically generate a JWT token for the newly registered operator for immediate login. (`src/main/java/elytra/stations_management/controller/AuthController.java`)

### Test Updates:
* Adjusted the `registerOperator_ShouldCreateOperator_WhenAdmin` test to reflect the changes in the registration flow, including the removal of station ID as a required field and the addition of token generation. (`src/test/java/elytra/stations_management/controller/AuthControllerTest.java`) [[1]](diffhunk://#diff-e0739d04e498a8bf8d65e7f6039e4c7aba468aa44ea58ffbf9cb1d266e542abeL481-R482) [[2]](diffhunk://#diff-e0739d04e498a8bf8d65e7f6039e4c7aba468aa44ea58ffbf9cb1d266e542abeL491-R507)