### PR TITLE
Setup test containers with mysql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,21 @@
 			<version>0.8.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mysql</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/test/java/elytra/stations_management/TestContainerExample.java
+++ b/src/test/java/elytra/stations_management/TestContainerExample.java
@@ -1,0 +1,26 @@
+package elytra.stations_management;
+
+import elytra.stations_management.config.TestContainerConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.MySQLContainer;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("mysql-test")
+@ContextConfiguration(classes = TestContainerConfig.class)
+class TestContainerExample {
+
+    @Autowired
+    private MySQLContainer<?> mysqlContainer;
+
+    @Test
+    void testMySQLContainerIsRunning() {
+        assertTrue(mysqlContainer.isRunning(), "MySQL container should be running");
+        assertTrue(mysqlContainer.getJdbcUrl().contains("mysql"), "JDBC URL should contain mysql");
+    }
+}

--- a/src/test/java/elytra/stations_management/config/TestContainerConfig.java
+++ b/src/test/java/elytra/stations_management/config/TestContainerConfig.java
@@ -1,0 +1,22 @@
+package elytra.stations_management.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfig {
+
+    @Bean
+    public MySQLContainer<?> mysqlContainer() {
+        MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                .withDatabaseName("testdb")
+                .withUsername("test")
+                .withPassword("test")
+                .withReuse(true);
+        
+        mysql.start();
+        return mysql;
+    }
+}

--- a/src/test/java/elytra/stations_management/integration/AuthenticationIntegrationTest.java
+++ b/src/test/java/elytra/stations_management/integration/AuthenticationIntegrationTest.java
@@ -1,6 +1,7 @@
 package elytra.stations_management.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import elytra.stations_management.config.TestContainerConfig;
 import elytra.stations_management.models.AuthRequest;
 import elytra.stations_management.models.User;
 import elytra.stations_management.repositories.UserRepository;
@@ -9,12 +10,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -25,6 +28,8 @@ import static org.hamcrest.Matchers.*;
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
+@Testcontainers
+@Import(TestContainerConfig.class)
 class AuthenticationIntegrationTest {
 
     @Autowired

--- a/src/test/resources/application-mysql-test.properties
+++ b/src/test/resources/application-mysql-test.properties
@@ -1,6 +1,11 @@
-spring.application.name=stations-management-test
+# MySQL Test Container Configuration
+spring.application.name=stations-management-mysql-test
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
+
+# This will be overridden by test container configuration
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 # Disable features not needed in tests
 spring.h2.console.enabled=false


### PR DESCRIPTION
This pull request introduces Testcontainers for integration testing with a MySQL database, replacing the in-memory H2 database in specific test profiles. Key changes include adding dependencies, configuring a MySQL Testcontainer, and updating test classes and properties files to support the new setup.

### Testcontainers Integration:

* Added Testcontainers dependencies (`junit-jupiter`, `mysql`, and `mysql-connector-j`) to `pom.xml` to enable containerized testing with MySQL.
* Created `TestContainerConfig` class to define and configure a reusable MySQL Testcontainer for tests. The container is initialized with database credentials and starts automatically.
* Introduced a new test class, `TestContainerExample`, to validate the MySQL Testcontainer functionality, ensuring it is running and properly configured.

### Test Class Updates:

* Updated `AuthenticationIntegrationTest` to use the MySQL Testcontainer by importing `TestContainerConfig` and adding the `@Testcontainers` annotation. [[1]](diffhunk://#diff-4377a5c67a2af2ccc0decf3b5054379a52674eed01c86093c8e9d35e5ecf10dbR4) [[2]](diffhunk://#diff-4377a5c67a2af2ccc0decf3b5054379a52674eed01c86093c8e9d35e5ecf10dbR13-R20) [[3]](diffhunk://#diff-4377a5c67a2af2ccc0decf3b5054379a52674eed01c86093c8e9d35e5ecf10dbR31-R32)

### Configuration Changes:

* Added `application-mysql-test.properties` to configure the MySQL Testcontainer profile, including database settings, JWT configuration, and disabling unnecessary features for testing.
* Updated `application-test.properties` to remove H2-specific configurations and disable SQL logging for tests.