### PR TITLE
add controller to get driver id with userid

### DIFF
--- a/src/main/java/elytra/stations_management/controller/EVDriverController.java
+++ b/src/main/java/elytra/stations_management/controller/EVDriverController.java
@@ -33,6 +33,15 @@ public class EVDriverController {
         }
     }
 
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<EVDriver> getDriverByUserId(@PathVariable Long userId) {
+        try {
+            return ResponseEntity.ok(evDriverService.getDriverByUserId(userId));
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     @GetMapping
     public ResponseEntity<List<EVDriver>> getAllDrivers() {
         return ResponseEntity.ok(evDriverService.getAllDrivers());


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve an `EVDriver` by their `userId` in the `EVDriverController` class.

### New API Endpoint:
* Added a `GET` endpoint `/user/{userId}` in `EVDriverController` to fetch an `EVDriver` by `userId`. The method returns a `200 OK` response with the driver details if found, or a `404 Not Found` response if the driver is not found. (`src/main/java/elytra/stations_management/controller/EVDriverController.java`, [src/main/java/elytra/stations_management/controller/EVDriverController.javaR36-R44](diffhunk://#diff-9602e38254e519cf1a579191ea1bab81c2607cde22d64e6d782664a835cceca3R36-R44))